### PR TITLE
MVP-224: Fixed refresh expiry issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/citz-imb-sso-react",
-  "version": "1.0.0-alpha5",
+  "version": "1.0.0-alpha6",
   "description": "BCGov SSO integration for React",
   "author": "CITZ IMB Common Code <citz.codemvp@gov.bc.ca>",
   "license": "Apache-2.0",

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -14,6 +14,7 @@ import { AuthContext } from '../context';
  * @property {Function} [onRefreshExpiry] - Function to call when refresh token expires.
  * @property {boolean} [overrideShowRefreshExpiryDialog] - Show RefreshExpiryDialog.
  * @property {string} [postLoginRedirectURL] - Redirect url after login.
+ * @property {number} [refreshExpiresInOffset] - Offset for when onRefreshExpiry is called (seconds).
  */
 export const SSOProvider = (props: SSOProviderProps) => {
   const {
@@ -23,6 +24,7 @@ export const SSOProvider = (props: SSOProviderProps) => {
     onRefreshExpiry,
     overrideShowRefreshExpiryDialog,
     postLoginRedirectURL,
+    refreshExpiresInOffset,
   } = props;
   const [isExpiryDialogVisible, setIsExpiryDialogVisible] = useState(false);
 
@@ -36,6 +38,7 @@ export const SSOProvider = (props: SSOProviderProps) => {
         onRefreshExpiry={
           onRefreshExpiry ? () => onRefreshExpiry() : () => setIsExpiryDialogVisible(true)
         }
+        refreshExpiresInOffset={refreshExpiresInOffset}
       >
         {children}
       </SSOWrapper>

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,13 @@ export type SSOProviderProps = {
   onRefreshExpiry?: Function;
   overrideShowRefreshExpiryDialog?: boolean;
   postLoginRedirectURL?: string;
+  refreshExpiresInOffset?: number;
 };
 export type SSOWrapperProps = {
   backendURL?: string | undefined;
   children: ReactNode;
   onRefreshExpiry?: Function;
+  refreshExpiresInOffset?: number | undefined;
 };
 export type LoginProps = {
   backendURL?: string | undefined;

--- a/techdocs/docs/using-the-package/typescript-types.md
+++ b/techdocs/docs/using-the-package/typescript-types.md
@@ -33,6 +33,7 @@ type SSOProviderProps = { // Login related props are used by the default Refresh
     onRefreshExpiry?: Function; // Custom function to run when refresh token expires.
     overrideShowRefreshExpiryDialog?: boolean; // Used for testing the refresh expiry dialog by forcing it to show.
     postLoginRedirectURL?: string; // URL to redirect to after login.
+    refreshExpiresInOffset?: number; // Offset for when onRefreshExpiry is called (seconds).
 };
 
 type LoginProps = {


### PR DESCRIPTION
<!--  
PR Title format:  
JIRA_BOARD_ABBREVIATION-JIRA_TASK_NUMBER: TITLE_OF_JIRA_TASK  

MVP-100: Title of Ticket
-->

## 🎯 Summary

<!-- COMPLETE JIRA LINK BELOW -->  
[MVP-224](https://citz-imb.atlassian.net/jira/browse/MVP-224)

<!-- PROVIDE BELOW an explanation of your changes and any images to support your explanation -->
Updated to alpha6.

Issue was caused by the login redirect canceling the setTimeout for the refresh expiry function.

Test by running `npm run build` in this projects root directory, then running `npm run rebuild:override` in the `citz-imb-common-code` repo.

You can set `refreshExpiresInOffset` prop on `SSOProvider` to `-1770` to force the pop up to show after about a 30 seconds.

Also ensure you have also cloned the sso-css-api and sso-express repos and run `npm run build` in those projects for the override to work.

## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
